### PR TITLE
GAS-105 Switch PMM to user service manager

### DIFF
--- a/roles/container/tasks/podman.yaml
+++ b/roles/container/tasks/podman.yaml
@@ -5,19 +5,41 @@
   register: container_image_pull
 
 - block:
-    - block:
-        - name: Check podman for --no-healthcheck support
-          ansible.builtin.shell:
-            cmd: podman run --help | grep -Fq 'no-healthcheck'
-          changed_when: false
-          ignore_errors: true
-          register: container_podman_healthcheck_check
+    - name: Check podman for --no-healthcheck support
+      ansible.builtin.shell:
+        cmd: podman run --help | grep -Fq 'no-healthcheck'
+      changed_when: false
+      ignore_errors: true
+      register: container_podman_healthcheck_check
 
-        - name: Set healthcheck fact
-          ansible.builtin.set_fact:
-            container_healthcheck: "{{ '--health-cmd=none --health-interval=disable' if (container_podman_healthcheck_check.rc is undefined or container_podman_healthcheck_check.rc|int == 1) else '--no-healthcheck' }}"
-      when: container_rootless
+    - name: Set healthcheck fact
+      ansible.builtin.set_fact:
+        container_healthcheck: "{{ '--health-cmd=none --health-interval=disable' if (container_podman_healthcheck_check.rc is undefined or container_podman_healthcheck_check.rc|int == 1) else '--no-healthcheck' }}"
 
+    - name: Create ~/.config/systemd/user
+      ansible.builtin.file:
+        path: ~/.config/systemd/user
+        state: directory
+        mode: u=rwX,g=rX,o=
+
+    - name: Create the systemd unit file
+      ansible.builtin.template:
+        src: container-unit-file.j2
+        dest: '~/.config/systemd/user/{{ container_service.name }}.service'
+        owner: '{{ container_service.user | default(ansible_user_uid) }}'
+        group: '{{ container_service.group | default(ansible_user_gid) }}'
+        mode: u=rw,a=r
+      register: container_service_unit
+
+    - name: Start the container
+      ansible.builtin.systemd:
+        name: '{{ container_service.name }}'
+        daemon_reload: '{{ container_service_unit.changed|bool }}'
+        enabled: true
+        state: '{{ "restarted" if (container_service_unit.changed|bool or container_force_reload|bool) else "started" }}'
+  when: container_service.name is defined and container_rootless
+
+- block:
     - name: Create the systemd unit file
       ansible.builtin.template:
         src: container-unit-file.j2

--- a/roles/container/templates/container-unit-file.j2
+++ b/roles/container/templates/container-unit-file.j2
@@ -7,8 +7,10 @@ After=time-sync.target
 
 [Service]
 Type=simple
+{% if not container_rootless %}
 User={{ container_service.user | default(ansible_env.SUDO_UID) }}
 Group={{ container_service.group | default(ansible_env.SUDO_GID) }}
+{% endif %}
 SuccessExitStatus=0 125
 ExecStartPre=/usr/bin/bash -c '/usr/bin/podman stop -t 10 {{ container_service.name }} || true; /usr/bin/podman rm -f {{ container_service.name }} || true'
 ExecStart=/usr/bin/podman run --rm --name={{ container_service.name }} --env-file="{{ container_env_file }}" {{ container_healthcheck | default('') }} {{ container_service.extra_args | default('') }} {{ container_image }}

--- a/roles/pmm/defaults/main.yaml
+++ b/roles/pmm/defaults/main.yaml
@@ -52,7 +52,7 @@ pmm_container_image_repo: '{{ "docker.io/perconalab" if [pmm_version]|intersect(
 pmm_container_port: 8443
 pmm_container_volume: pmm-data
 
-pmm_deploy_using: podman
+pmm_deploy_using: '{{ container_engine | default("podman") }}'
 
 pmm_manage_users: []
 # - user: xxx


### PR DESCRIPTION
* Updated pmm_deploy_using to default to container_engine, with a fallback to podman
* Updated container/podman tasks to use the user service manager when container_rootless