### PR TITLE
GAS-106 Fix missing scope for rootless containers

### DIFF
--- a/roles/container/tasks/podman.yaml
+++ b/roles/container/tasks/podman.yaml
@@ -36,6 +36,7 @@
         name: '{{ container_service.name }}'
         daemon_reload: '{{ container_service_unit.changed|bool }}'
         enabled: true
+        scope: user
         state: '{{ "restarted" if (container_service_unit.changed|bool or container_force_reload|bool) else "started" }}'
   when: container_service.name is defined and container_rootless
 


### PR DESCRIPTION
The scope attribute was missing from the task that manages the systemd service for the rootless container.

* Fixed missing scope attribute