### PR TITLE
GAS 111 Install Percona Toolkit via system packages

### DIFF
--- a/roles/tools/defaults/main.yaml
+++ b/roles/tools/defaults/main.yaml
@@ -1,9 +1,4 @@
 ---
-tools_percona_toolkit_version: 3.4.0
-tools_percona_toolkit_url: "https://downloads.percona.com/downloads/percona-toolkit/{{ tools_percona_toolkit_version}}/binary/tarball/percona-toolkit-{{ tools_percona_toolkit_version }}_x86_64.tar.gz"
-tools_percona_toolkit_tmp_file: "/tmp/percona-toolkit-{{ tools_percona_toolkit_version }}_x86_64.tar.gz"
-tools_percona_toolkit_sha256: "{{ tools_percona_toolkit_url}}.sha256sum"
-tools_percona_toolkit_tmp_dir: "/tmp/percona-toolkit-{{ tools_percona_toolkit_version }}"
 tools_percona_toolkit_repo: pt
 
 tools_home_dir: "{{ ansible_env.HOME }}"

--- a/roles/tools/tasks/centos_7.yaml
+++ b/roles/tools/tasks/centos_7.yaml
@@ -9,10 +9,8 @@
 
 - name: Install extra tools
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ tools_packages }}"
     state: present
-  with_items:
-    - "{{ tools_packages }}"
   become: yes
   tags:
     - sudo

--- a/roles/tools/tasks/centos_8.yaml
+++ b/roles/tools/tasks/centos_8.yaml
@@ -1,10 +1,8 @@
 ---
 - name: Install extra tools
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ tools_packages }}"
     state: present
-  with_items:
-    - "{{ tools_packages }}"
   become: yes
   tags:
     - sudo

--- a/roles/tools/tasks/centos_8.yaml
+++ b/roles/tools/tasks/centos_8.yaml
@@ -7,11 +7,18 @@
   tags:
     - sudo
 
+- name: Add percona gpg rpm key
+  ansible.builtin.rpm_key:
+    state: present
+    key: "{{ tools_percona_gpg_key_url }}"
+  become: yes
+  tags:
+    - sudo
+
 - name: Install percona-release package
   ansible.builtin.package:
-    name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    name: "{{ tools_percona_release_url }}"
     state: present
-    disable_gpg_check: yes
   become: yes
   tags:
     - sudo

--- a/roles/tools/tasks/centos_9.yaml
+++ b/roles/tools/tasks/centos_9.yaml
@@ -1,46 +1,52 @@
 ---
-- name: Install extra tools
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "{{ tools_packages }}"
-  become: yes
-  tags:
-    - sudo
-
-- name: Ensure user bin directory exists
-  ansible.builtin.file:
-    path: "{{ tools_user_bin_dir }}"
-    state: directory
-
-- name: Install Percona Toolkit dependencies
-  ansible.builtin.package:
-    name: "{{ tools_percona_toolkit_dependencies }}"
-    state: present
-  become: yes
-
-- name: Download Percona Toolkit tarball
-  ansible.builtin.get_url:
-    url: "{{ tools_percona_toolkit_url }}"
-    dest: "{{ tools_percona_toolkit_tmp_file }}"
-    checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
-
-- name: Extract Percona Toolkit tarball
-  ansible.builtin.unarchive:
-    src: "{{ tools_percona_toolkit_tmp_file }}"
-    dest: "/tmp"
-    remote_src: yes
-
-- name: Move Percona Toolkit files to user bin directory
-  shell: "mv {{ tools_percona_toolkit_tmp_dir }}/bin/* {{ tools_user_bin_dir }}"
-
-- name: Percona Toolkit install cleanup
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ tools_percona_toolkit_tmp_file }}"
-    - "{{ tools_percona_toolkit_tmp_dir }}"
-
+- name: Check for the percona toolkit tarball
+  ansible.builtin.stat:
+    path: "{{ tools_percona_toolkit_tmp_file }}"
+  register: tools_percona_toolkit_status
+  
+- block:  
+  - name: Install extra tools
+    ansible.builtin.package:
+      name: "{{ tools_packages }}"
+      state: present
+    become: yes
+    tags:
+      - sudo
+  
+  - name: Ensure user bin directory exists
+    ansible.builtin.file:
+      path: "{{ tools_user_bin_dir }}"
+      state: directory
+  
+  - name: Install Percona Toolkit dependencies
+    ansible.builtin.package:
+      name: "{{ tools_percona_toolkit_dependencies }}"
+      state: present
+    become: yes
+  
+  - name: Download Percona Toolkit tarball
+    ansible.builtin.get_url:
+      url: "{{ tools_percona_toolkit_url }}"
+      dest: "{{ tools_percona_toolkit_tmp_file }}"
+      checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
+  
+  - name: Extract Percona Toolkit tarball
+    ansible.builtin.unarchive:
+      src: "{{ tools_percona_toolkit_tmp_file }}"
+      dest: "/tmp"
+      remote_src: yes
+  
+  - name: Copy Percona Toolkit files to user bin directory
+    ansible.builtin.copy:
+      src: "{{ tools_percona_toolkit_tmp_dir }}/bin/"
+      dest: "{{ tools_user_bin_dir }}"
+      remote_src: yes
+  
+  - name: Percona Toolkit install cleanup
+    ansible.builtin.file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+      - "{{ tools_percona_toolkit_tmp_dir }}"
+  when: not tools_percona_toolkit_status.stat.exists
 ...

--- a/roles/tools/tasks/centos_9.yaml
+++ b/roles/tools/tasks/centos_9.yaml
@@ -10,14 +10,14 @@
 - name: Add percona gpg rpm key
   ansible.builtin.rpm_key:
     state: present
-    key: https://www.percona.com/downloads/RPM-GPG-KEY-percona
+    key: "{{ tools_percona_gpg_key_url }}"
   become: yes
   tags:
     - sudo
 
 - name: Install percona-release package
   ansible.builtin.package:
-    name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    name: "{{ tools_percona_release_url }}"
     state: present
   become: yes
   tags:

--- a/roles/tools/tasks/centos_9.yaml
+++ b/roles/tools/tasks/centos_9.yaml
@@ -1,52 +1,33 @@
 ---
-- name: Check for the percona toolkit tarball
-  ansible.builtin.stat:
-    path: "{{ tools_percona_toolkit_tmp_file }}"
-  register: tools_percona_toolkit_status
-  
-- block:  
-  - name: Install extra tools
-    ansible.builtin.package:
-      name: "{{ tools_packages }}"
-      state: present
-    become: yes
-    tags:
-      - sudo
-  
-  - name: Ensure user bin directory exists
-    ansible.builtin.file:
-      path: "{{ tools_user_bin_dir }}"
-      state: directory
-  
-  - name: Install Percona Toolkit dependencies
-    ansible.builtin.package:
-      name: "{{ tools_percona_toolkit_dependencies }}"
-      state: present
-    become: yes
-  
-  - name: Download Percona Toolkit tarball
-    ansible.builtin.get_url:
-      url: "{{ tools_percona_toolkit_url }}"
-      dest: "{{ tools_percona_toolkit_tmp_file }}"
-      checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
-  
-  - name: Extract Percona Toolkit tarball
-    ansible.builtin.unarchive:
-      src: "{{ tools_percona_toolkit_tmp_file }}"
-      dest: "/tmp"
-      remote_src: yes
-  
-  - name: Copy Percona Toolkit files to user bin directory
-    ansible.builtin.copy:
-      src: "{{ tools_percona_toolkit_tmp_dir }}/bin/"
-      dest: "{{ tools_user_bin_dir }}"
-      remote_src: yes
-  
-  - name: Percona Toolkit install cleanup
-    ansible.builtin.file:
-      path: "{{ item }}"
-      state: absent
-    with_items:
-      - "{{ tools_percona_toolkit_tmp_dir }}"
-  when: not tools_percona_toolkit_status.stat.exists
+- name: Install extra tools
+  ansible.builtin.package:
+    name: "{{ tools_packages }}"
+    state: present
+  become: yes
+  tags:
+    - sudo
+
+- name: Install percona-release package
+  ansible.builtin.package:
+    name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    state: present
+    disable_gpg_check: yes
+  become: yes
+  tags:
+    - sudo
+
+- name: enable percona toolkit repo
+  ansible.builtin.command: "percona-release enable {{ tools_percona_toolkit_repo }}"
+  become: yes
+  tags:
+    - sudo
+
+- name: Install percona toolkit
+  ansible.builtin.package:
+    name: percona-toolkit
+    state: present
+  become: yes
+  tags:
+    - sudo
+
 ...

--- a/roles/tools/tasks/centos_9.yaml
+++ b/roles/tools/tasks/centos_9.yaml
@@ -7,11 +7,18 @@
   tags:
     - sudo
 
+- name: Add percona gpg rpm key
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://www.percona.com/downloads/RPM-GPG-KEY-percona
+  become: yes
+  tags:
+    - sudo
+
 - name: Install percona-release package
   ansible.builtin.package:
     name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     state: present
-    disable_gpg_check: yes
   become: yes
   tags:
     - sudo

--- a/roles/tools/tasks/debian_11.yaml
+++ b/roles/tools/tasks/debian_11.yaml
@@ -8,10 +8,8 @@
 
 - name: Install extra tools
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ tools_packages }}"
     state: present
-  with_items:
-    - "{{ tools_packages }}"
   become: yes
   tags:
     - sudo

--- a/roles/tools/tasks/oraclelinux_8.yaml
+++ b/roles/tools/tasks/oraclelinux_8.yaml
@@ -1,10 +1,8 @@
 ---
 - name: Install extra tools
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ tools_packages }}"
     state: present
-  with_items:
-    - "{{ tools_packages }}"
   become: yes
   tags:
     - sudo

--- a/roles/tools/tasks/redhat_8.yaml
+++ b/roles/tools/tasks/redhat_8.yaml
@@ -1,10 +1,8 @@
 ---
 - name: Install extra tools
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ tools_packages }}"
     state: present
-  with_items:
-    - "{{ tools_packages }}"
   become: yes
   tags:
     - sudo

--- a/roles/tools/tasks/redhat_8.yaml
+++ b/roles/tools/tasks/redhat_8.yaml
@@ -7,9 +7,17 @@
   tags:
     - sudo
 
+- name: Add percona gpg rpm key
+  ansible.builtin.rpm_key:
+    state: present
+    key: "{{ tools_percona_gpg_key_url }}"
+  become: yes
+  tags:
+    - sudo
+
 - name: Install percona-release package
   ansible.builtin.package:
-    name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    name: "{{ tools_percona_release_url }}"
     state: present
   become: yes
   tags:

--- a/roles/tools/tasks/redhat_9.yaml
+++ b/roles/tools/tasks/redhat_9.yaml
@@ -1,52 +1,40 @@
 ---
-- name: Check for the percona toolkit tarball
-  ansible.builtin.stat:
-    path: "{{ tools_percona_toolkit_tmp_file }}"
-  register: tools_percona_toolkit_status
+- name: Install extra tools
+  ansible.builtin.package:
+    name: "{{ tools_packages }}"
+    state: present
+  become: yes
+  tags:
+    - sudo
 
-- block:
-  - name: Install extra tools
-    ansible.builtin.package:
-      name: "{{ tools_packages }}"
-      state: present
-    become: yes
-    tags:
-      - sudo
-  
-  - name: Ensure user bin directory exists
-    ansible.builtin.file:
-      path: "{{ tools_user_bin_dir }}"
-      state: directory
-  
-  - name: Install Percona Toolkit dependencies
-    ansible.builtin.package:
-      name: "{{ tools_percona_toolkit_dependencies }}"
-      state: present
-    become: yes
-  
-  - name: Download Percona Toolkit tarball
-    ansible.builtin.get_url:
-      url: "{{ tools_percona_toolkit_url }}"
-      dest: "{{ tools_percona_toolkit_tmp_file }}"
-      checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
-  
-  - name: Extract Percona Toolkit tarball
-    ansible.builtin.unarchive:
-      src: "{{ tools_percona_toolkit_tmp_file }}"
-      dest: "/tmp"
-      remote_src: yes
-  
-  - name: Copy Percona Toolkit files to user bin directory
-    ansible.builtin.copy:
-      src: "{{ tools_percona_toolkit_tmp_dir }}/bin/"
-      dest: "{{ tools_user_bin_dir }}"
-      remote_src: yes
-  
-  - name: Percona Toolkit install cleanup
-    ansible.builtin.file:
-      path: "{{ item }}"
-      state: absent
-    with_items:
-      - "{{ tools_percona_toolkit_tmp_dir }}"
-  when: not tools_percona_toolkit_status.stat.exists
+- name: Add percona gpg rpm key
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://www.percona.com/downloads/RPM-GPG-KEY-percona
+  become: yes
+  tags:
+    - sudo
+
+- name: Install percona-release package
+  ansible.builtin.package:
+    name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    state: present
+  become: yes
+  tags:
+    - sudo
+
+- name: enable percona toolkit repo
+  ansible.builtin.command: "percona-release enable {{ tools_percona_toolkit_repo }}"
+  become: yes
+  tags:
+    - sudo
+
+- name: Install percona toolkit
+  ansible.builtin.package:
+    name: percona-toolkit
+    state: present
+  become: yes
+  tags:
+    - sudo
+
 ...

--- a/roles/tools/tasks/redhat_9.yaml
+++ b/roles/tools/tasks/redhat_9.yaml
@@ -1,46 +1,52 @@
 ---
-- name: Install extra tools
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "{{ tools_packages }}"
-  become: yes
-  tags:
-    - sudo
+- name: Check for the percona toolkit tarball
+  ansible.builtin.stat:
+    path: "{{ tools_percona_toolkit_tmp_file }}"
+  register: tools_percona_toolkit_status
 
-- name: Ensure user bin directory exists
-  ansible.builtin.file:
-    path: "{{ tools_user_bin_dir }}"
-    state: directory
-
-- name: Install Percona Toolkit dependencies
-  ansible.builtin.package:
-    name: "{{ tools_percona_toolkit_dependencies }}"
-    state: present
-  become: yes
-
-- name: Download Percona Toolkit tarball
-  ansible.builtin.get_url:
-    url: "{{ tools_percona_toolkit_url }}"
-    dest: "{{ tools_percona_toolkit_tmp_file }}"
-    checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
-
-- name: Extract Percona Toolkit tarball
-  ansible.builtin.unarchive:
-    src: "{{ tools_percona_toolkit_tmp_file }}"
-    dest: "/tmp"
-    remote_src: yes
-
-- name: Move Percona Toolkit files to user bin directory
-  shell: "mv {{ tools_percona_toolkit_tmp_dir }}/bin/* {{ tools_user_bin_dir }}"
-
-- name: Percona Toolkit install cleanup
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ tools_percona_toolkit_tmp_file }}"
-    - "{{ tools_percona_toolkit_tmp_dir }}"
-
+- block:
+  - name: Install extra tools
+    ansible.builtin.package:
+      name: "{{ tools_packages }}"
+      state: present
+    become: yes
+    tags:
+      - sudo
+  
+  - name: Ensure user bin directory exists
+    ansible.builtin.file:
+      path: "{{ tools_user_bin_dir }}"
+      state: directory
+  
+  - name: Install Percona Toolkit dependencies
+    ansible.builtin.package:
+      name: "{{ tools_percona_toolkit_dependencies }}"
+      state: present
+    become: yes
+  
+  - name: Download Percona Toolkit tarball
+    ansible.builtin.get_url:
+      url: "{{ tools_percona_toolkit_url }}"
+      dest: "{{ tools_percona_toolkit_tmp_file }}"
+      checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
+  
+  - name: Extract Percona Toolkit tarball
+    ansible.builtin.unarchive:
+      src: "{{ tools_percona_toolkit_tmp_file }}"
+      dest: "/tmp"
+      remote_src: yes
+  
+  - name: Copy Percona Toolkit files to user bin directory
+    ansible.builtin.copy:
+      src: "{{ tools_percona_toolkit_tmp_dir }}/bin/"
+      dest: "{{ tools_user_bin_dir }}"
+      remote_src: yes
+  
+  - name: Percona Toolkit install cleanup
+    ansible.builtin.file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+      - "{{ tools_percona_toolkit_tmp_dir }}"
+  when: not tools_percona_toolkit_status.stat.exists
 ...

--- a/roles/tools/tasks/redhat_9.yaml
+++ b/roles/tools/tasks/redhat_9.yaml
@@ -10,14 +10,14 @@
 - name: Add percona gpg rpm key
   ansible.builtin.rpm_key:
     state: present
-    key: https://www.percona.com/downloads/RPM-GPG-KEY-percona
+    key: "{{ tools_percona_gpg_key_url }}"
   become: yes
   tags:
     - sudo
 
 - name: Install percona-release package
   ansible.builtin.package:
-    name: https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    name: "{{ tools_percona_release_url }}"
     state: present
   become: yes
   tags:

--- a/roles/tools/tasks/ubuntu_22.yaml
+++ b/roles/tools/tasks/ubuntu_22.yaml
@@ -1,59 +1,45 @@
 ---
-- name: Check for the percona toolkit tarball
-  ansible.builtin.stat:
-    path: "{{ tools_percona_toolkit_tmp_file }}"
-  register: tools_percona_toolkit_status
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: yes
+  become: yes
+  tags:
+    - sudo
 
-- block:
-  - name: Update apt cache
-    ansible.builtin.apt:
-      update_cache: yes
-    become: yes
-    tags:
-      - sudo
-  
-  - name: Install extra tools
-    ansible.builtin.package:
-      name: "{{ tools_packages }}"
-      state: present
-    become: yes
-    tags:
-      - sudo
-  
-  - name: Ensure user bin directory exists
-    ansible.builtin.file:
-      path: "{{ tools_user_bin_dir }}"
-      state: directory
-  
-  - name: Install Percona Toolkit dependencies
-    ansible.builtin.package:
-      name: "{{ tools_percona_toolkit_dependencies }}"
-      state: present
-    become: yes
-  
-  - name: Download Percona Toolkit tarball
-    ansible.builtin.get_url:
-      url: "{{ tools_percona_toolkit_url }}"
-      dest: "{{ tools_percona_toolkit_tmp_file }}"
-      checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
-  
-  - name: Extract Percona Toolkit tarball
-    ansible.builtin.unarchive:
-      src: "{{ tools_percona_toolkit_tmp_file }}"
-      dest: "/tmp"
-      remote_src: yes
-  
-  - name: Copy Percona Toolkit files to user bin directory
-    ansible.builtin.copy:
-      src: "{{ tools_percona_toolkit_tmp_dir }}/bin/"
-      dest: "{{ tools_user_bin_dir }}"
-      remote_src: yes
-  
-  - name: Percona Toolkit install cleanup
-    ansible.builtin.file:
-      path: "{{ item }}"
-      state: absent
-    with_items:
-      - "{{ tools_percona_toolkit_tmp_dir }}"
-  when: not tools_percona_toolkit_status.stat.exists
+- name: Install extra tools
+  ansible.builtin.package:
+    name: "{{ tools_packages }}"
+    state: present
+  become: yes
+  tags:
+    - sudo
+
+- name: Install percona-release package dependencies
+  ansible.builtin.package: 
+    name: "{{ tools_percona_release_dependencies }}"
+    state: present
+  become: yes
+  tags:
+    - sudo
+
+- name: Install percona-release
+  ansible.builtin.apt:
+    deb: "https://repo.percona.com/apt/percona-release_latest.{{ ansible_distribution_release }}_all.deb"
+  become: yes
+  tags:
+    - sudo 
+
+- name: Setup percona toolkit repo
+  ansible.builtin.command: "percona-release enable {{ tools_percona_toolkit_repo }}"
+  become: yes
+  tags:
+    - sudo
+
+- name: Install percona toolkit
+  ansible.builtin.apt:
+    name: percona-toolkit
+    state: present
+  become: yes
+  tags:
+    - sudo
 ...

--- a/roles/tools/tasks/ubuntu_22.yaml
+++ b/roles/tools/tasks/ubuntu_22.yaml
@@ -1,53 +1,59 @@
 ---
-- name: Update apt cache
-  ansible.builtin.apt:
-    update_cache: yes
-  become: yes
-  tags:
-    - sudo
+- name: Check for the percona toolkit tarball
+  ansible.builtin.stat:
+    path: "{{ tools_percona_toolkit_tmp_file }}"
+  register: tools_percona_toolkit_status
 
-- name: Install extra tools
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "{{ tools_packages }}"
-  become: yes
-  tags:
-    - sudo
-
-- name: Ensure user bin directory exists
-  ansible.builtin.file:
-    path: "{{ tools_user_bin_dir }}"
-    state: directory
-
-- name: Install Percona Toolkit dependencies
-  ansible.builtin.package:
-    name: "{{ tools_percona_toolkit_dependencies }}"
-    state: present
-  become: yes
-
-- name: Download Percona Toolkit tarball
-  ansible.builtin.get_url:
-    url: "{{ tools_percona_toolkit_url }}"
-    dest: "{{ tools_percona_toolkit_tmp_file }}"
-    checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
-
-- name: Extract Percona Toolkit tarball
-  ansible.builtin.unarchive:
-    src: "{{ tools_percona_toolkit_tmp_file }}"
-    dest: "/tmp"
-    remote_src: yes
-
-- name: Move Percona Toolkit files to user bin directory
-  shell: "mv {{ tools_percona_toolkit_tmp_dir }}/bin/* {{ tools_user_bin_dir }}"
-
-- name: Percona Toolkit install cleanup
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ tools_percona_toolkit_tmp_file }}"
-    - "{{ tools_percona_toolkit_tmp_dir }}"
-
+- block:
+  - name: Update apt cache
+    ansible.builtin.apt:
+      update_cache: yes
+    become: yes
+    tags:
+      - sudo
+  
+  - name: Install extra tools
+    ansible.builtin.package:
+      name: "{{ tools_packages }}"
+      state: present
+    become: yes
+    tags:
+      - sudo
+  
+  - name: Ensure user bin directory exists
+    ansible.builtin.file:
+      path: "{{ tools_user_bin_dir }}"
+      state: directory
+  
+  - name: Install Percona Toolkit dependencies
+    ansible.builtin.package:
+      name: "{{ tools_percona_toolkit_dependencies }}"
+      state: present
+    become: yes
+  
+  - name: Download Percona Toolkit tarball
+    ansible.builtin.get_url:
+      url: "{{ tools_percona_toolkit_url }}"
+      dest: "{{ tools_percona_toolkit_tmp_file }}"
+      checksum: "sha256:{{ tools_percona_toolkit_sha256 }}"
+  
+  - name: Extract Percona Toolkit tarball
+    ansible.builtin.unarchive:
+      src: "{{ tools_percona_toolkit_tmp_file }}"
+      dest: "/tmp"
+      remote_src: yes
+  
+  - name: Copy Percona Toolkit files to user bin directory
+    ansible.builtin.copy:
+      src: "{{ tools_percona_toolkit_tmp_dir }}/bin/"
+      dest: "{{ tools_user_bin_dir }}"
+      remote_src: yes
+  
+  - name: Percona Toolkit install cleanup
+    ansible.builtin.file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+      - "{{ tools_percona_toolkit_tmp_dir }}"
+  when: not tools_percona_toolkit_status.stat.exists
 ...

--- a/roles/tools/vars/centos.yaml
+++ b/roles/tools/vars/centos.yaml
@@ -1,9 +1,1 @@
 ---
-tools_percona_toolkit_dependencies:
-  - perl
-  - perl-DBD-MySQL
-  - perl-DBI
-  - perl-Digest-MD5
-  - perl-IO-Socket-SSL
-  - perl-TermReadKey
-  - perl-Time-HiRes

--- a/roles/tools/vars/debian.yaml
+++ b/roles/tools/vars/debian.yaml
@@ -1,10 +1,3 @@
 ---
-tools_percona_toolkit_dependencies:
-  - perl
-  - libdbi-perl
-  - libdbd-mysql-perl
-  - libterm-readkey-perl
-  - libio-socket-ssl-perl
-
 tools_percona_release_dependencies:
   - gnupg2

--- a/roles/tools/vars/main.yaml
+++ b/roles/tools/vars/main.yaml
@@ -1,3 +1,6 @@
 ---
 tools_packages:
   - jq
+
+tools_percona_gpg_key_url: https://www.percona.com/downloads/RPM-GPG-KEY-percona
+tools_percona_release_url: https://repo.percona.com/yum/percona-release-latest.noarch.rpm

--- a/roles/tools/vars/main.yaml
+++ b/roles/tools/vars/main.yaml
@@ -1,4 +1,3 @@
 ---
 tools_packages:
   - jq
-

--- a/roles/tools/vars/oraclelinux.yaml
+++ b/roles/tools/vars/oraclelinux.yaml
@@ -1,9 +1,1 @@
 ---
-tools_percona_toolkit_dependencies:
-  - perl
-  - perl-DBD-MySQL
-  - perl-DBI
-  - perl-Digest-MD5
-  - perl-IO-Socket-SSL
-  - perl-TermReadKey
-  - perl-Time-HiRes

--- a/roles/tools/vars/redhat.yaml
+++ b/roles/tools/vars/redhat.yaml
@@ -1,9 +1,1 @@
 ---
-tools_percona_toolkit_dependencies:
-  - perl
-  - perl-DBD-MySQL
-  - perl-DBI
-  - perl-Digest-MD5
-  - perl-IO-Socket-SSL
-  - perl-TermReadKey
-  - perl-Time-HiRes

--- a/roles/tools/vars/ubuntu.yaml
+++ b/roles/tools/vars/ubuntu.yaml
@@ -1,10 +1,3 @@
 ---
-tools_percona_toolkit_dependencies:
-  - perl
-  - libdbi-perl
-  - libdbd-mysql-perl
-  - libterm-readkey-perl
-  - libio-socket-ssl-perl
-
 tools_percona_release_dependencies:
   - gnupg2


### PR DESCRIPTION
* Since percona toolkit is now available for Ubuntu 22 and RHEL/CentOS 9 reworked the tools role to install via yum
* Other optimizations