### PR TITLE
GAS-115 Allow the default PMM credentials to be used

### DIFF
--- a/roles/pmm/tasks/api-assertions.yaml
+++ b/roles/pmm/tasks/api-assertions.yaml
@@ -100,6 +100,12 @@
   when: pmm_admin_use_token | bool
 
 - block:
+    - name: Use default credentials
+      ansible.builtin.set_fact:
+        pmm_admin_password_new: admin
+      when: pmm_admin_is_default and pmm_admin_password_new is undefined
+
+- block:
     - name: Test username and password
       ansible.builtin.uri:
         url: '{{ pmm_server_uri }}{{ pmm_api_version }}'


### PR DESCRIPTION
Whilst normal usage should change the admin credentials, certain scenarios (such as non-interactive operations, quick user tests, etc) would benefit from not requiring the change.

* Added fallback option to default password in pmm/api-assertions