### PR TITLE
GAS-124: Write out .kube/config from multiple sources.

### DIFF
--- a/roles/tools/defaults/main.yaml
+++ b/roles/tools/defaults/main.yaml
@@ -3,7 +3,9 @@ tools_percona_toolkit_repo: pt
 
 tools_home_dir: "{{ ansible_env.HOME }}"
 
+tools_kubectl_config_file: "{{ tools_home_dir }}/.kube/config"
 tools_kubectl_configuration: ''
+tools_kubectl_envs_from_pmm: []
 tools_kubectl_required: false
 tools_kubectl_image: docker.io/bitnami/kubectl
 tools_kubectl_image_tag: 1.25
@@ -23,6 +25,9 @@ tools_mysql_install: "{{ 'mysql' in groups and groups['mysql'] | length > 0 }}"
 tools_mysql_versions:
   - 5.7
   - 8.0
+
+tools_pmm_user: "{{ pmm_admin_credentials.split(':')[0] }}"
+tools_pmm_pass: "{{ pmm_admin_credentials.split(':')[1] }}"
 
 tools_profile_path: "{{ tools_home_dir }}/.bashrc"
 

--- a/roles/tools/tasks/kubectl.yaml
+++ b/roles/tools/tasks/kubectl.yaml
@@ -14,13 +14,16 @@
   tags:
     - config
 
-- name: Create kube config
-  ansible.builtin.copy:
-    content: '{{ tools_kubectl_configuration }}'
-    dest: '{{ tools_home_dir }}/.kube/config'
-    create: yes
-    owner: '{{ ansible_env.USER }}'
-    mode: u=rw,g=r,o=
+- name: Check for .kube/config
+  ansible.builtin.stat: 
+    path: "{{ tools_kubectl_config_file }}"
+  register: tools_kubectl_config_check
+  tags:
+    - config
+
+- name: Include kubectl config tasks
+  include_tasks: kubectl_config.yaml
+  when: not tools_kubectl_config_check.stat.exists
   tags:
     - config
 

--- a/roles/tools/tasks/kubectl_config.yaml
+++ b/roles/tools/tasks/kubectl_config.yaml
@@ -1,0 +1,33 @@
+---
+- name: Create kube config if tools_kubectl_configuration defined
+  ansible.builtin.copy:
+    content: '{{ tools_kubectl_configuration }}'
+    dest: '{{ tools_kubectl_config_file }}'
+    owner: '{{ ansible_env.USER }}'
+    mode: u=rw,g=r,o=
+  when: tools_kubectl_configuration | length > 0
+
+- name: Get k8s envs from pmm-server if tools_k8s_envs_from_pmm is empty
+  block:
+    - name: Query pmm for k8s envs
+      ansible.builtin.uri:
+        url: "https://{{ pmm_server_host }}:{{ pmm_server_port }}/v1/management/DBaaS/Kubernetes/List"
+        user: "{{ tools_pmm_user }}"
+        password: "{{ tools_pmm_pass }}"
+        method: POST
+        force_basic_auth: yes
+        headers:
+          accept: "application/json"
+        validate_certs: "{{ pmm_server_insecure }}"
+      register: tools_kubectl_env_list
+
+    - name: Populate tools_k8s_envs_from_pmm
+      ansible.builtin.set_fact:
+        tools_kubectl_envs_from_pmm: "{{ tools_kubectl_envs_from_pmm + [ item.kubernetes_cluster_name ] }}"
+      with_items: "{{ tools_kubectl_env_list.json.kubernetes_clusters }}"
+  when: tools_kubectl_envs_from_pmm | length == 0
+
+- name: Include tasks to write pmm kube config to file
+  include_tasks: write_pmm_kubectl_config.yaml
+  loop: "{{ tools_kubectl_envs_from_pmm }}"
+  when: tools_kubectl_envs_from_pmm | length > 0

--- a/roles/tools/tasks/write_pmm_kubectl_config.yaml
+++ b/roles/tools/tasks/write_pmm_kubectl_config.yaml
@@ -1,0 +1,43 @@
+---
+- name: Checking for .kube config file
+  ansible.builtin.stat:
+    path: "{{ tools_kubectl_config_file }}"
+  register: tools_kubectl_config_check
+
+- name: Set tools_kubectl_env_config_file default
+  ansible.builtin.set_fact:
+    tools_kubectl_env_config_file: "{{ tools_kubectl_config_file }}"
+
+- name: Set tools_kube_config_name
+  ansible.builtin.set_fact:
+    tools_kubectl_env_config_file: "{{ tools_kubectl_config_file }}_{{ item }}"
+  when: tools_kubectl_config_check.stat.exists
+
+- name: Retrieve kube config from pmm
+  ansible.builtin.uri:
+    url: "https://{{ pmm_server_host }}:{{ pmm_server_port }}/v1/management/DBaaS/Kubernetes/Get"
+    user: "{{ tools_pmm_user }}"
+    password: "{{ tools_pmm_pass }}"
+    method: POST
+    force_basic_auth: yes
+    headers: 
+      accept: "application/json"
+      content-type: "application/json"
+    body:
+      kubernetes_cluster_name: "{{ item }}"
+    body_format: json
+    validate_certs: '{{ pmm_server_insecure }}'
+  register: tools_kubectl_from_pmm
+
+- name: Set tools_kubectl_config
+  ansible.builtin.set_fact:
+    tools_kubectl_config: "{{ tools_kubectl_from_pmm.json.kube_auth.kubeconfig }}"
+
+- name: Write kube config from pmm to file
+  ansible.builtin.copy:
+    content: "{{ tools_kubectl_config }}"
+    dest: "{{ tools_kubectl_env_config_file }}"
+    owner: "{{ ansible_env.USER }}"
+    mode: u=rw,g=r,o=
+  tags:
+    - config


### PR DESCRIPTION
* Moved kubectl config tasks to their own file
* Added variables for use when pulling kubectl config from pmm server
* Added logic to pull kubectl config(s) from pmm-server if they are avaialble.  
* Can also specify which kubectl config's to pull from pmm server