### PR TITLE
GAS-166: PostgreSQL socket path should be a directory

### DIFF
--- a/roles/pmm/vars/main.yaml
+++ b/roles/pmm/vars/main.yaml
@@ -64,7 +64,7 @@ pmm_payload_add_postgresql_base:
   database: postgres
   query_source: pgstatements
   service_name: '{{ inventory_hostname }}-postgresql'
-  socket: /var/run/postgresql/.s.PGSQL.5432
+  socket: /var/run/postgresql
 pmm_payload_add_proxysql_base:
   host: 127.0.0.1
   port: 6032


### PR DESCRIPTION
Default PSQL socket path we are using in gascan playbooks points to a PSQL socket file but `pmm-agent` uses directory path and appends the socket file path to it. This leads to adding PSQL nodes failure, as the socket file path gets appended twice