### PR TITLE
GAS-169: Add PostgreSQL tools

### DIFF
--- a/pmm-full.yaml
+++ b/pmm-full.yaml
@@ -2,18 +2,18 @@
 - name: PMM Server
   ansible.builtin.import_playbook: pmm-server.yaml
   tags:
-  - pmm
-  - server
+    - pmm
+    - server
 
 - name: Tooling
   ansible.builtin.import_playbook: tools.yaml
   tags:
-  - tools
-  - server
+    - tools
+    - server
 
 - name: PMM Client
   ansible.builtin.import_playbook: pmm-client.yaml
   tags:
-  - pmm
-  - client
+    - pmm
+    - client
 ...

--- a/roles/tools/defaults/main.yaml
+++ b/roles/tools/defaults/main.yaml
@@ -24,6 +24,7 @@ tools_mysql_versions:
   - 5.7
   - 8.0
 
+tools_postgresql_conf: "{{ ansible_env.HOME }}/.pgpass"
 tools_postgresql_image: docker.io/perconalab/percona-distribution-postgresql
 tools_postgresql_install: "{{ 'postgresql' in groups and groups['postgresql'] | length > 0 }}"
 tools_postgresql_versions:

--- a/roles/tools/defaults/main.yaml
+++ b/roles/tools/defaults/main.yaml
@@ -24,6 +24,16 @@ tools_mysql_versions:
   - 5.7
   - 8.0
 
+tools_postgresql_conf:
+tools_postgresql_image: docker.io/perconalab/percona-distribution-postgresql
+tools_postgresql_install: "{{ 'postgresql' in groups and groups['postgresql'] | length > 0 }}"
+tools_postgresql_versions:
+  - 11.18
+  - 12.13
+  - 13.9
+  - 14.6
+  - 15.1
+
 tools_profile_path: "{{ tools_home_dir }}/.bashrc"
 
 tools_user_bin_dir: "{{ tools_home_dir }}/bin"

--- a/roles/tools/defaults/main.yaml
+++ b/roles/tools/defaults/main.yaml
@@ -24,7 +24,6 @@ tools_mysql_versions:
   - 5.7
   - 8.0
 
-tools_postgresql_conf:
 tools_postgresql_image: docker.io/perconalab/percona-distribution-postgresql
 tools_postgresql_install: "{{ 'postgresql' in groups and groups['postgresql'] | length > 0 }}"
 tools_postgresql_versions:

--- a/roles/tools/tasks/main.yaml
+++ b/roles/tools/tasks/main.yaml
@@ -23,6 +23,15 @@
   tags:
     - mysql
 
+- name: Install PostgreSQL clients
+  ansible.builtin.include_tasks: postgresql-client.yaml
+  vars:
+    tools_postgresql_image_tag: '{{ item }}'
+  loop: '{{ tools_postgresql_versions }}'
+  when: tools_postgresql_install
+  tags:
+    - postgresql
+
 - name: Include distro specific variables
   ansible.builtin.include_vars: '{{ ansible_distribution | lower }}.yaml'
 

--- a/roles/tools/tasks/postgresql-client.yaml
+++ b/roles/tools/tasks/postgresql-client.yaml
@@ -9,7 +9,7 @@
   ansible.builtin.lineinfile:
     path: '{{ tools_profile_path }}'
     create: yes
-    line: "alias psql{{ tools_postgresql_image_tag }}='podman run --rm -it --entrypoint=psql -v {{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'"
+    line: "alias psql{{ tools_postgresql_image_tag }}='podman run --rm -it --entrypoint=psql {{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'"
     owner: '{{ ansible_env.USER }}'
     mode: u=rw,g=r,o=
 ...

--- a/roles/tools/tasks/postgresql-client.yaml
+++ b/roles/tools/tasks/postgresql-client.yaml
@@ -1,0 +1,15 @@
+---
+- name: Prepare the PostgreSQL container image
+  ansible.builtin.include_role:
+    name: container
+  vars:
+    container_image: '{{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'
+
+- name: Add alias for PostgreSQL CLI
+  ansible.builtin.lineinfile:
+    path: '{{ tools_profile_path }}'
+    create: yes
+    line: "alias psql{{ tools_postgresql_image_tag }}='podman run --rm -it --entrypoint=psql -v {{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'"
+    owner: '{{ ansible_env.USER }}'
+    mode: u=rw,g=r,o=
+...

--- a/roles/tools/tasks/postgresql-client.yaml
+++ b/roles/tools/tasks/postgresql-client.yaml
@@ -5,11 +5,24 @@
   vars:
     container_image: '{{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'
 
+- name: Check for tools_postgresql_conf
+  ansible.builtin.stat:
+    path: '{{ tools_postgresql_conf }}'
+  register: tools_stat_postgresql_conf
+
+- name: Ensure that the mounted files exist
+  ansible.builtin.copy:
+    dest: '{{ tools_postgresql_conf }}'
+    content: >
+      # This file is unmanaged
+    mode: u=rw,g=r,o=
+  when: not tools_stat_postgresql_conf.stat.exists
+
 - name: Add alias for PostgreSQL CLI
   ansible.builtin.lineinfile:
     path: '{{ tools_profile_path }}'
     create: yes
-    line: "alias psql{{ tools_postgresql_image_tag }}='podman run --rm -it --entrypoint=psql {{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'"
+    line: "alias psql{{ tools_postgresql_image_tag }}='podman run --rm -it --entrypoint=psql -v {{ tools_postgresql_conf }}:/home/postgres/{{ tools_postgresql_conf | basename }}:z {{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'"
     owner: '{{ ansible_env.USER }}'
     mode: u=rw,g=r,o=
 ...


### PR DESCRIPTION
`gascan` should install PostgreSQL clients in the same way MySQL and MongoDB clients are installed