### PR TITLE
GAS-181: Adjust tools role for mongosh in MongoDB 6.0 image.

### DIFF
--- a/roles/tools/defaults/main.yaml
+++ b/roles/tools/defaults/main.yaml
@@ -8,9 +8,11 @@ tools_kubectl_required: false
 tools_kubectl_image: docker.io/bitnami/kubectl
 tools_kubectl_image_tag: 1.25
 
-tools_mongodb_conf: "{{ ansible_env.HOME }}/.mongorc.js"
+tools_mongodb_conf: "{{ ansible_env.HOME }}/.{{ tools_mongodb_cli }}.js"
 tools_mongodb_image: docker.io/percona/percona-server-mongodb
 tools_mongodb_install: "{{ 'mongodb' in groups and groups['mongodb'] | length > 0 }}"
+tools_mongodb_mongosh:
+  - 6.0
 tools_mongodb_versions:
   - 4.2
   - 4.4

--- a/roles/tools/defaults/main.yaml
+++ b/roles/tools/defaults/main.yaml
@@ -8,7 +8,7 @@ tools_kubectl_required: false
 tools_kubectl_image: docker.io/bitnami/kubectl
 tools_kubectl_image_tag: 1.25
 
-tools_mongodb_conf: "{{ ansible_env.HOME }}/.{{ tools_mongodb_cli }}.js"
+tools_mongodb_conf: "{{ ansible_env.HOME }}/.{{ tools_mongodb_cli }}rc.js"
 tools_mongodb_image: docker.io/percona/percona-server-mongodb
 tools_mongodb_install: "{{ 'mongodb' in groups and groups['mongodb'] | length > 0 }}"
 tools_mongodb_mongosh:

--- a/roles/tools/tasks/mongodb-client.yaml
+++ b/roles/tools/tasks/mongodb-client.yaml
@@ -5,6 +5,10 @@
   vars:
     container_image: '{{ tools_mongodb_image }}:{{ tools_mongodb_image_tag }}'
 
+- name: Set tools_mongodb_cli fact
+  set_fact:
+    tools_mongodb_cli: "{{ 'mongosh' if (tools_mongodb_image_tag in tools_mongodb_mongosh) else 'mongo' }}"
+
 - name: Check for tools_mongodb_conf
   ansible.builtin.stat:
     path: '{{ tools_mongodb_conf }}'
@@ -14,14 +18,14 @@
   ansible.builtin.copy:
     dest: '{{ tools_mongodb_conf }}'
     content: >
-      # This file is unmanaged
+      // This file is unmanaged
   when: not tools_stat_mongodb_conf.stat.exists
 
 - name: Add alias for MongoDB CLI
   ansible.builtin.lineinfile:
     path: '{{ tools_profile_path }}'
     create: yes
-    line: "alias mongo{{ tools_mongodb_image_tag }}='podman run --rm -it --entrypoint=mongo -v {{ tools_mongodb_conf }}:/home/mongodb/{{ tools_mongodb_conf | basename }}:z {{ tools_mongodb_image }}:{{ tools_mongodb_image_tag }}'"
+    line: "alias mongo{{ tools_mongodb_image_tag }}='podman run --rm -it --entrypoint={{ tools_mongodb_cli }} -v {{ tools_mongodb_conf }}:/home/mongodb/{{ tools_mongodb_conf | basename }}:z {{ tools_mongodb_image }}:{{ tools_mongodb_image_tag }}'"
     owner: '{{ ansible_env.USER }}'
     mode: u=rw,g=r,o=
 ...

--- a/roles/tools/tasks/mongodb-client.yaml
+++ b/roles/tools/tasks/mongodb-client.yaml
@@ -6,7 +6,7 @@
     container_image: '{{ tools_mongodb_image }}:{{ tools_mongodb_image_tag }}'
 
 - name: Set tools_mongodb_cli fact
-  set_fact:
+  ansible.builtin.set_fact:
     tools_mongodb_cli: "{{ 'mongosh' if (tools_mongodb_image_tag in tools_mongodb_mongosh) else 'mongo' }}"
 
 - name: Check for tools_mongodb_conf


### PR DESCRIPTION
* Adjusted `tools_mongodb_conf` variable to use a fact (tools_mongodb_cli) which is set in the mongodb-client.yaml task file.
* Added tools_mongodb_mongosh to track mongodb image versions that have mongosh and not mongo.  
* Added a set_fact task to check version and create/adjust the tools_mongodb_cli based on version.  
* Adjusted the "Add alias for MongoDB CLI" task to spcify the correct mongo cli tool (tools_mongodb_cli).  